### PR TITLE
Update/add several testing libraries

### DIFF
--- a/build_libraries.toml
+++ b/build_libraries.toml
@@ -6,6 +6,7 @@ androidx_cardview = "1.0.0"
 androidx_constraint_layout = "2.1.1"
 androidx_core = "1.1.0"
 androidx_core_ktx = "1.3.2"
+androidx_databinding = "7.0.2" # Used for Robolectric workaround, should match AGP version
 androidx_fragment = "1.3.2"
 androidx_fragment_testing = "1.1.0"
 androidx_legacy_preference_v14 = "1.0.0"
@@ -17,13 +18,12 @@ androidx_navigation = "2.3.4"
 androidx_paging = "2.1.0"
 androidx_preference = "1.1.1"
 androidx_recycler_view = "1.1.0"
-androidx_test_espresso = "3.3.0-alpha02"
-androidx_test_espresso_core = "3.1.0"
-androidx_test_ext_junit = "1.1.2-alpha02"
-androidx_test_extensions = "1.1.1"
-androidx_test_orchestrator = "1.1.0"
-androidx_test_rules = "1.1.0"
-androidx_test_runner = "1.1.0"
+androidx_test_espresso_core = "3.4.0"
+androidx_test_core_ktx = "1.4.0"
+androidx_test_ext_junit_ktx = "1.1.3"
+androidx_test_orchestrator = "1.4.0"
+androidx_test_rules = "1.4.0"
+androidx_test_runner = "1.4.0"
 androidx_view_pager2 = "1.0.0"
 androidx_webkit = "1.4.0"
 bouncycastle = "1.67"
@@ -50,6 +50,9 @@ jcip_annotations = "1.0-1"
 joda_time = "2.10.10"
 junit = "4.12"
 junit_jupiter = "5.7.1"
+junit_vintage_engine = "5.5.2" # Vintage engine specifically targeting current JUnit version (4.12)
+junit5_mannodermaus = "1.3.0"
+kluent = "1.68"
 kotlin = "1.5.30"
 kotlin_coroutines = "1.3.7"
 kxml = "2.3.0"
@@ -59,7 +62,7 @@ logback_classic = "1.3.0-alpha5"
 mockito = "2.27.0"
 mockito_android = "2.22.0"
 mockito_core = "3.4.4"
-mockito_kotlin = "2.2.0"
+mockito_kotlin = "4.0.0"
 mockwebserver = "4.9.0"
 moshi = "1.12.0"
 nano_httpd = "c3b149e04df161c85daeef02899128e727148b02"
@@ -88,7 +91,7 @@ r2_opds = "2.1.1"
 r2_shared = "2.1.1"
 r2_streamer = "2.1.1"
 retrofit2 = "2.9.0"
-robolectric = "4.4"
+robolectric = "4.7.3"
 rxandroid = "2.1.1"
 rxjava = "1.3.8"
 rxjava2 = "2.2.21"
@@ -104,6 +107,7 @@ androidx_cardview = { module = "androidx.cardview:cardview", version.ref = "andr
 androidx_constraint_layout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx_constraint_layout" }
 androidx_core = { module = "androidx.core:core", version.ref = "androidx_core" }
 androidx_core_ktx = { module = "androidx.core:core-ktx", version.ref = "androidx_core_ktx" }
+androidx_databinding_kapt = { module = "androidx.databinding:databinding-compiler", version.ref = "androidx_databinding" }
 androidx_fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx_fragment" }
 androidx_fragment_testing = { module = "androidx.fragment:fragment-testing", version.ref = "androidx_fragment_testing" }
 androidx_legacy_preference_v14 = { module = "androidx.legacy:legacy-preference-v14", version.ref = "androidx_legacy_preference_v14" }
@@ -116,10 +120,9 @@ androidx_navigation_ui = { module = "androidx.navigation:navigation-ui-ktx", ver
 androidx_paging = { module = "androidx.paging:paging-runtime-ktx", version.ref = "androidx_paging" }
 androidx_preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx_preference" }
 androidx_recycler_view = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx_recycler_view" }
-androidx_test_espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx_test_espresso" }
+androidx_test_core_ktx = { module = "androidx.test:core-ktx", version.ref = "androidx_test_core_ktx"}
 androidx_test_espresso_core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx_test_espresso_core" }
-androidx_test_ext_junit = { module = "androidx.test.ext:junit", version.ref = "androidx_test_ext_junit" }
-androidx_test_extensions = { module = "androidx.test.ext:junit", version.ref = "androidx_test_extensions" }
+androidx_test_ext_junit_ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx_test_ext_junit_ktx" }
 androidx_test_orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidx_test_orchestrator" }
 androidx_test_rules = { module = "androidx.test:rules", version.ref = "androidx_test_rules" }
 androidx_test_runner = { module = "androidx.test:runner", version.ref = "androidx_test_runner" }
@@ -159,6 +162,10 @@ joda_time = { module = "joda-time:joda-time", version.ref = "joda_time" }
 junit = { module = "junit:junit", version.ref = "junit" }
 junit_jupiter_api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit_jupiter" }
 junit_jupiter_engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit_jupiter" }
+junit_vintage_engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit_vintage_engine" }
+junit5_android_test_core = { module = "de.mannodermaus.junit5:android-test-core", version.ref = "junit5_mannodermaus" }
+junit5_android_test_runner = { module = "de.mannodermaus.junit5:android-test-runner", version.ref = "junit5_mannodermaus" }
+kluent_android = { module = "org.amshove.kluent:kluent-android", version.ref = "kluent" }
 kotlin_coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin_coroutines" }
 kotlin_coroutines_android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlin_coroutines" }
 kotlin_reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
@@ -169,7 +176,7 @@ logback_android = { module = "com.github.tony19:logback-android", version.ref = 
 logback_classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback_classic" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito_android = { module = "org.mockito:mockito-android", version.ref = "mockito_android" }
-mockito_kotlin = { module = "com.nhaarman.mockitokotlin2:mockito-kotlin", version.ref = "mockito_kotlin" }
+mockito_kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito_kotlin" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi_kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }


### PR DESCRIPTION
- Move to official mockito-kotlin
- Remove some unnecessary dependencies that were added transitively through their kotlin versions
- Remove some duplicate dependencies
- Add AndroidXTest Core
- Add Kluent for kotlin assertions
- Add Junit5 Android dependencies
- Add Junit Vintage Engine for legacy JUnit support