### PR TITLE
Updated nanohttpd version

### DIFF
--- a/build_libraries.toml
+++ b/build_libraries.toml
@@ -88,8 +88,8 @@ mockito_kotlin = "4.0.0"
 mockk = "1.12.0" # 1.12.1 seems to re-introduce this issue https://github.com/mockk/mockk/issues/754
 mockwebserver = "4.9.0"
 moshi = "1.12.0"
-nano_httpd = "c3b149e04df161c85daeef02899128e727148b02"
-nano_httpd_nanolets = "c3b149e04df161c85daeef02899128e727148b02"
+nano_httpd = "master-SNAPSHOT"
+nano_httpd_nanolets = "master-SNAPSHOT"
 nimbus_jose_jwt = "8.20"
 nypl_audiobook = "7.1.0"
 nypl_drm_adobe = "1.2.4"
@@ -228,8 +228,8 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi_kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
-nano_httpd = { module = "com.github.edrlab.nanohttpd:nanohttpd", version.ref = "nano_httpd" }
-nano_httpd_nanolets = { module = "com.github.edrlab.nanohttpd:nanohttpd-nanolets", version.ref = "nano_httpd_nanolets" }
+nano_httpd = { module = "com.github.readium.nanohttpd:nanohttpd", version.ref = "nano_httpd" }
+nano_httpd_nanolets = { module = "com.github.readium.nanohttpd:nanohttpd-nanolets", version.ref = "nano_httpd_nanolets" }
 nimbus_jose_jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus_jose_jwt" }
 nypl_audiobook_api = { module = "org.librarysimplified.audiobook:org.librarysimplified.audiobook.api", version.ref = "nypl_audiobook" }
 nypl_audiobook_downloads = { module = "org.librarysimplified.audiobook:org.librarysimplified.audiobook.downloads", version.ref = "nypl_audiobook" }


### PR DESCRIPTION
The old version by EDR Labs was deleted from Github. This deletion also affected Readium, so @roywatson and I followed their lead in fixing it: https://github.com/readium/kotlin-toolkit/commit/d312903177fef46004eeea89b76a724bbbcda0b3